### PR TITLE
KN_Build mart models with cumulative metrics

### DIFF
--- a/transform/models/marts/repo_pushes_daily.sql
+++ b/transform/models/marts/repo_pushes_daily.sql
@@ -3,7 +3,7 @@ SELECT
     repo_name,
     DATE_TRUNC('day', event_date) AS date_day,
     COUNT(*) AS push_count,
-    SUM(COUNT(*)) OVER (PARTITION BY repo_id ORDER BY DATE_TRUNC('day', event_date) ASC) AS cumul_push_count
+    SUM(push_count) OVER (PARTITION BY repo_id ORDER BY date_day ASC) AS cumul_push_count
 FROM {{ ref("stg_gharchive")}}
 WHERE event_type = 'Push'
 GROUP BY 1, 2, 3

--- a/transform/models/marts/repo_pushes_daily.sql
+++ b/transform/models/marts/repo_pushes_daily.sql
@@ -1,0 +1,9 @@
+SELECT
+    repo_id,
+    repo_name,
+    DATE_TRUNC('day', event_date) AS date_day,
+    COUNT(*) AS push_count,
+    SUM(COUNT(*)) OVER (PARTITION BY repo_id ORDER BY DATE_TRUNC('day', event_date) ASC) AS cumul_push_count
+FROM {{ ref("stg_gharchive")}}
+WHERE event_type = 'Push'
+GROUP BY 1, 2, 3

--- a/transform/models/marts/repo_pushes_monthly.sql
+++ b/transform/models/marts/repo_pushes_monthly.sql
@@ -1,0 +1,9 @@
+SELECT
+    repo_id,
+    repo_name,
+    DATE_TRUNC('month', event_date) AS date_month,
+    COUNT(*) AS push_count,
+    SUM(COUNT(*)) OVER (PARTITION BY repo_id ORDER BY DATE_TRUNC('month', event_date) ASC) AS cumul_push_count
+FROM {{ ref("stg_gharchive")}}
+WHERE event_type = 'Push'
+GROUP BY 1, 2, 3

--- a/transform/models/marts/repo_pushes_monthly.sql
+++ b/transform/models/marts/repo_pushes_monthly.sql
@@ -3,7 +3,7 @@ SELECT
     repo_name,
     DATE_TRUNC('month', event_date) AS date_month,
     COUNT(*) AS push_count,
-    SUM(COUNT(*)) OVER (PARTITION BY repo_id ORDER BY DATE_TRUNC('month', event_date) ASC) AS cumul_push_count
+    SUM(push_count) OVER (PARTITION BY repo_id ORDER BY date_month ASC) AS cumul_push_count
 FROM {{ ref("stg_gharchive")}}
 WHERE event_type = 'Push'
 GROUP BY 1, 2, 3

--- a/transform/models/marts/repo_stars_daily.sql
+++ b/transform/models/marts/repo_stars_daily.sql
@@ -3,7 +3,7 @@ SELECT
     repo_name,
     DATE_TRUNC('day', event_date) AS date_day,
     COUNT(*) AS star_count,
-    SUM(COUNT(*)) OVER (PARTITION BY repo_id ORDER BY DATE_TRUNC('day', event_date) ASC) AS cumul_star_count
+    SUM(star_count) OVER (PARTITION BY repo_id ORDER BY date_day ASC) AS cumul_star_count
 FROM {{ ref("stg_gharchive")}}
 WHERE event_type = 'Watch'
 GROUP BY 1, 2, 3

--- a/transform/models/marts/repo_stars_daily.sql
+++ b/transform/models/marts/repo_stars_daily.sql
@@ -1,0 +1,9 @@
+SELECT
+    repo_id,
+    repo_name,
+    DATE_TRUNC('day', event_date) AS date_day,
+    COUNT(*) AS star_count,
+    SUM(COUNT(*)) OVER (PARTITION BY repo_id ORDER BY DATE_TRUNC('day', event_date) ASC) AS cumul_star_count
+FROM {{ ref("stg_gharchive")}}
+WHERE event_type = 'Watch'
+GROUP BY 1, 2, 3

--- a/transform/models/marts/repo_stars_monthly.sql
+++ b/transform/models/marts/repo_stars_monthly.sql
@@ -1,0 +1,9 @@
+SELECT
+    repo_id,
+    repo_name,
+    DATE_TRUNC('month', event_date) AS date_month,
+    COUNT(*) AS star_count,
+    SUM(COUNT(*)) OVER (PARTITION BY repo_id ORDER BY DATE_TRUNC('month', event_date) ASC) AS cumul_star_count
+FROM {{ ref("stg_gharchive")}}
+WHERE event_type = 'Watch'
+GROUP BY 1, 2, 3

--- a/transform/models/marts/repo_stars_monthly.sql
+++ b/transform/models/marts/repo_stars_monthly.sql
@@ -3,7 +3,7 @@ SELECT
     repo_name,
     DATE_TRUNC('month', event_date) AS date_month,
     COUNT(*) AS star_count,
-    SUM(COUNT(*)) OVER (PARTITION BY repo_id ORDER BY DATE_TRUNC('month', event_date) ASC) AS cumul_star_count
+    SUM(star_count) OVER (PARTITION BY repo_id ORDER BY date_month ASC) AS cumul_star_count
 FROM {{ ref("stg_gharchive")}}
 WHERE event_type = 'Watch'
 GROUP BY 1, 2, 3


### PR DESCRIPTION
- Add four views models sorted by stars and pushes, daily and monthly
- Add cumulative metrics to keep trace of total stars and pushes